### PR TITLE
Allow the theme root directory to be filtered

### DIFF
--- a/main.php
+++ b/main.php
@@ -2,7 +2,7 @@
 function check_main( $theme ) {
 	global $themechecks, $data, $themename;
 	$themename = $theme;
-	$theme = get_theme_root( $theme ) . "/$theme";
+	$theme = apply_filters( 'tc_theme_root', get_theme_root( $theme ) . "/$theme", $theme );
 	$files = listdir( $theme );
 	$data = tc_get_theme_data( $theme . '/style.css' );
 	if ( $data[ 'Template' ] ) {


### PR DESCRIPTION
It would be useful to filter the theme root directory in contexts where theme developers are using Grunt or similar inside the theme directory. In my example, I use Grunt to create a build inside the theme root (under `build/theme-name`). Running Theme Check on the theme root results in directories & files being covered that don't _need_ to be covered. Think things like sass, node_modules, CSS maps, etc. 

A filter here would just be a simple way to get around this for theme developers, to allow them to build their theme however they want without sacrificing ease of testing with Theme Check.

Cheers, 
Eric
